### PR TITLE
add default database name otherwise newly created Wordpress will comp…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - db-data:/var/lib/mysql:z
     environment:
       MYSQL_ROOT_PASSWORD: r00tpwd
+      MYSQL_DATABASE: wordpress
   #adminer:
   #  image: adminer@sha256:0e245b5550d7710ebfe728e682804947e2edade4d7f3313e7066b4629b728c5c
   #  ports:


### PR DESCRIPTION
add default database name otherwise newly created Wordpress will complain `Unknown database 'wordpress'`